### PR TITLE
add rust version and MSRV CI

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,30 @@
+name: Check MSRV
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - src/**/*.rs
+      - Cargo.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - src/**/*.rs
+      - Cargo.toml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-min-rust-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-msrv
+      - name: Verify minimum rust version
+        run: cargo-msrv verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 # matches arrow 
-rust-version = "1.62"
+rust-version = "1.70.0"
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ include = [
     "README.md"
 ]
 
+# matches arrow 
+rust-version = "1.62"
+
 [lib]
 crate-type = ["staticlib", "lib"]
 name = 'arrow_extendr'


### PR DESCRIPTION
Closes #6 

Adds Rust version to `Cargo.toml` based on upstream arrow-rs version: 
https://github.com/apache/arrow-rs/blob/a0148ba4cea1756bd22c534dff14e362cb5ee242/Cargo.toml#L77C1-L77C22

Adds simple MSRV check in CI